### PR TITLE
Fixed a typo

### DIFF
--- a/src/kfun/std.cpp
+++ b/src/kfun/std.cpp
@@ -1351,7 +1351,7 @@ int kf_open_port(Frame *f, int nargs, kfunc *kf)
     unsigned short port;
     unsigned char protocol;
     char *protoname;
-    object *obj;
+    Object *obj;
 
     protocol = 0;
 


### PR DESCRIPTION
If you compile with -DNETWORK_EXTENSIONS things weren't compling.

This fixes it.