### PR TITLE
Possible fix for upgrade+destruct memory leak

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -715,7 +715,7 @@ void Object::del(Frame *f)
 	/* remove from object name hash table */
 	*oplane->htab->lookup(name, FALSE) = next;
 
-	if (--ref == 0 && !O_UPGRADING(this)) {
+	if (--ref == 0) {
 	    remove(f);
 	}
     } else {
@@ -723,7 +723,7 @@ void Object::del(Frame *f)
 
 	master = OBJW(this->master);
 	master->cref--;
-	if (--(master->ref) == 0 && !O_UPGRADING(master)) {
+	if (--(master->ref) == 0) {
 	    master->remove(f);
 	}
     }


### PR DESCRIPTION
It looks like this condition was added to prevent multiple reference
deletions, but Object::remove() should already handle this (by grabbing
the upgraded control), and the condition is preventing
upgraded-then-destructed objects from freeing inheritance references as
well as keeping the original object (not the copy created by
::upgrade()) from getting fully cleaned in ::clean() as ::remove() is
what adds the object to baseplane.destruct.